### PR TITLE
Pin dependency on arxiv package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='comparxiv',
           'tqdm',
           'argparse',
           'requests',
-          'arxiv'
+          'arxiv==0.5.3'
       ],
       entry_points = {
         'console_scripts': ['comparxiv=comparxiv.command_line:main'],


### PR DESCRIPTION
The `arxiv` package has gone through substantial API changes recently. The latest version of `arxiv` that `comparxiv`, as written, works with is 0.5.3. This change pins the version of `arxiv` so that the correct version gets installed.