### PR TITLE
Upgrade `arxiv` dependency to 1.4.1

### DIFF
--- a/comparxiv/comparxiv.py
+++ b/comparxiv/comparxiv.py
@@ -172,13 +172,7 @@ def latest_available_version(arxiv_ID):
 	if len(papers) == 0:
 		print("Error: The paper [%s] cannot be found on the preprint server." % (arxiv_ID))
 		os.abort()
-	version_max = 1
-	while version_max < 100:
-		papers = list_papers([arxiv_ID+"v"+str(version_max + 1)])
-		if len(papers) == 0:
-			break
-		version_max += 1
-	return version_max
+	return int(papers[0].get_short_id().split("v")[-1])
 
 def Generate_PDF(tex_file, folder, show_latex_output):
 	owd = os.getcwd()

--- a/comparxiv/comparxiv.py
+++ b/comparxiv/comparxiv.py
@@ -121,7 +121,7 @@ def compare_preprints(arxiv_ID, version_a, version_b,keep_temp,show_latex_output
 
 def print_paper_information(arxiv_ID,vA,vB):
 	to_id = lambda v: '{}v{}'.format(arxiv_ID, str(v))
-	papers = list(arxiv.Search(id_list=[to_id(vA),to_id(vB)],max_results=2).results())
+	papers = list_papers([to_id(vA),to_id(vB)])
 	if papers[0].title != papers[1].title:
 		print("New title:\t%s" % papers[1].title)
 		print("Old title:\t%s" % papers[0].title)
@@ -168,16 +168,14 @@ def check_arguments(arxiv_ID,vA,vB):
 		os.abort()	
 
 def latest_available_version(arxiv_ID):
-	papers = list(arxiv.Search(id_list=[arxiv_ID],max_results=1).results())
+	papers = list_papers([arxiv_ID])
 	if len(papers) == 0:
 		print("Error: The paper [%s] cannot be found on the preprint server." % (arxiv_ID))
 		os.abort()
 	version_max = 1
 	while version_max < 100:
-		try:
-			papers = list(arxiv.Search(id_list=[arxiv_ID+"v"+str(version_max + 1)], max_results=1).results())
-		except AttributeError:
-			# NOTE(lukasschwab): see lukasschwab/arxiv.py#80.
+		papers = list_papers([arxiv_ID+"v"+str(version_max + 1)])
+		if len(papers) == 0:
 			break
 		version_max += 1
 	return version_max
@@ -195,6 +193,12 @@ def Generate_PDF(tex_file, folder, show_latex_output):
 	os.system(pdflatex_command)
 	os.chdir(owd)
 
+def list_papers(ids):
+	try:
+		return list(arxiv.Search(id_list=ids).results())
+	except AttributeError:
+		# NOTE(lukasschwab): see lukasschwab/arxiv.py#80.
+		return []
 
 #Download the files from the preprint server, if it hasn't been done before.
 def download_from_url(url, destination):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='comparxiv',
           'tqdm',
           'argparse',
           'requests',
-          'arxiv==0.5.3'
+          'arxiv==1.4.1'
       ],
       entry_points = {
         'console_scripts': ['comparxiv=comparxiv.command_line:main'],

--- a/tests/test_comparxiv.py
+++ b/tests/test_comparxiv.py
@@ -11,7 +11,7 @@ def test_comparxiv(ID):
 	show_latex_output = False
 	dont_open_pdf = True
 	dont_compare_equations = False
-	assert compare_preprints(ID, 1, 2, keep_temp_files, show_latex_output, dont_open_pdf, dont_compare_equations)
+	assert compare_preprints(ID, 1, 2, keep_temp_files, show_latex_output, dont_open_pdf, dont_compare_equations), "comparison unsuccessful"
 
 @pytest.mark.parametrize("cmd, pdf",[
 	("comparxiv --dont_open_pdf 1907.06674 1 2","1907.06674_v1v2.pdf"),
@@ -22,5 +22,5 @@ def test_comparxiv(ID):
 ])
 def test_command_line(cmd, pdf):
 	os.system(cmd)
-	assert os.path.isfile(pdf)
+	assert os.path.isfile(pdf), "missing expected PDF output: {}".format(pdf)
 

--- a/tests/test_comparxiv.py
+++ b/tests/test_comparxiv.py
@@ -1,28 +1,26 @@
 #!/usr/bin/env python
 import os
+import pytest
 
 from comparxiv.comparxiv import *
 from comparxiv.command_line import *
 
-def test_comparxiv():
-	test_preprints = ["hep-ph/0612065","1709.06573","1901.04503","1905.05776"]
+@pytest.mark.parametrize("ID",["hep-ph/0612065","1709.06573","1901.04503","1905.05776"])
+def test_comparxiv(ID):
 	keep_temp_files = False
 	show_latex_output = False
 	dont_open_pdf = True
 	dont_compare_equations = False
-	for ID in test_preprints:
-		assert compare_preprints(ID, 1, 2, keep_temp_files, show_latex_output, dont_open_pdf, dont_compare_equations)
+	assert compare_preprints(ID, 1, 2, keep_temp_files, show_latex_output, dont_open_pdf, dont_compare_equations)
 
-def test_command_line():
-	tests = [
-		["comparxiv --dont_open_pdf 1907.06674 1 2","1907.06674_v1v2.pdf"],
-		["comparxiv --dont_open_pdf 1907.06674v3","1907.06674_v2v3.pdf"],
-		["comparxiv --dont_open_pdf 1410.0314 3","1410.0314_v2v3.pdf"],
-		["comparxiv --dont_open_pdf 1410.0314v1 3","1410.0314_v1v3.pdf"],
-		["comparxiv --dont_open_pdf 1709.06573","1709.06573_v1v2.pdf"]
-	]
-
-	for test in tests:
-		os.system(test[0])
-		assert os.path.isfile(test[1])
+@pytest.mark.parametrize("cmd, pdf",[
+	("comparxiv --dont_open_pdf 1907.06674 1 2","1907.06674_v1v2.pdf"),
+	("comparxiv --dont_open_pdf 1907.06674v3","1907.06674_v2v3.pdf"),
+	("comparxiv --dont_open_pdf 1410.0314 3","1410.0314_v2v3.pdf"),
+	("comparxiv --dont_open_pdf 1410.0314v1 3","1410.0314_v1v3.pdf"),
+	("comparxiv --dont_open_pdf 1709.06573","1709.06573_v1v2.pdf")
+])
+def test_command_line(cmd, pdf):
+	os.system(cmd)
+	assert os.path.isfile(pdf)
 


### PR DESCRIPTION
## Changes

+ Pins `arxiv==1.4.1`.
  + Factors out a `list_papers` helper to centralize exception-handling for nonexistent IDs.
+ Uses fully-qualified old-format arXiv IDs; see https://github.com/lukasschwab/arxiv.py/issues/74.
+ Parameterizes unit tests. Doesn't change which unit tests get run, but treats each set of parameters as its own pytest test.
+ Reduces lookup for paper version to a single request rather than iterating through all versions.

### Testing

Most of the unit tests fail in my local environment, but this seems to be a matter of missing required LaTeX packages: the `pdflatex` builds fail. *You may have better luck in your testing environment!*

Some of the tests *do* pass and generate the expected PDFs, which makes me confident in my use of the upgraded `arxiv` package. The `comparxiv` outputs for those failures include the expected authors and titles:

```
                                    __  ___
  ___ ___  _ __ ___  _ __   __ _ _ _\ \/ (_)_   __
 / __/ _ \| '_ ` _ \| '_ \ / _` | '__\  /| \ \ / /
| (_| (_) | | | | | | |_) | (_| | |  /  \| |\ V /
 \___\___/|_| |_| |_| .__/ \__,_|_| /_/\_\_| \_/
                    |_|

Version 0.1.7, developed by Timon Emken (2020)

Compare [1907.06674]: v2 vs v3

Title:		Death by Dark Matter
Authors:	 Jagjit Singh Sidhu, Robert J Scherrer, Glenn Starkman

1.) Download and unpack source files:

2.1) Identify master tex files:
	1907.06674v2:	main_bob_gds.tex
	1907.06674v3:	main_resubmit.tex

2.2) Identify bbl files:
	1907.06674v2:	main_bob_gds.bbl
	1907.06674v3:	main_resubmit.bbl

3.1) Run latexdiff on the tex files.

3.2) Run latexdiff on the bbl files.

4.) Generate a pdf with pdflatex.
	Warning: No pdf could be generated. Copy the .bbl file of version b and try again.

Failure! No pdf file could be generated.
Troubleshooting:
	1.) To see more terminal output run:
		'comparxiv --show_latex_output 1907.06674 2 3'
	2.) In some cases latex math environments cause problems with latexdiff. Try running:
		'comparxiv --dont_compare_equations 1907.06674 2 3'
```

## Notes

The `AttributeError` handling corresponds to a known bug: https://github.com/lukasschwab/arxiv.py/issues/80

When that bug is closed, the exception-handling here can be tightened or the `list_papers` helper can be removed altogether.

Feel free to treat this as really low-priority. The existing usage of the v0 client isn't broken, but v1 is simpler, better-typed, and easier to extend.